### PR TITLE
update base path selectively

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,8 +5,9 @@ import { PluginLoader } from "./PluginLoader";
 import { Sandbox } from "./Sandbox/Sandbox";
 
 const App = () => {
+    const base = (import.meta.env.BASE_URL || "/").replace(/\/+$/, "") + "/";
     return (
-        <BrowserRouter>
+        <BrowserRouter  basename={base}>
             <Routes>
                 <Route path="/embed/:pluginName" element={<PluginLoader />} />
                 <Route path="/sandbox/:pluginName" element={<Sandbox />} />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "target": "ESNext",
         "lib": ["dom", "dom.iterable", "esnext"],
-        // "types": ["vite/client"],
+        "types": ["vite/client"],
         // "allowJs": false,
         "skipLibCheck": true,
         "allowSyntheticDefaultImports": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,10 +33,8 @@ function manifestPlugin() {
         const langPath = path.join(languagesDir, lang);
         if (!(await fs.stat(langPath)).isDirectory()) continue;
 
-        // IMPORTANT: prefix with base so it works under /pickcode-plugins/ in prod
-        const prefix = base.endsWith("/") ? base : base + "/";
         manifest[pluginName][lang] = {
-          implUrl: `${prefix}plugins-code/${pluginName}/languages/${lang}/implementation.js`,
+          implUrl: `/plugins-code/${pluginName}/languages/${lang}/implementation.js`,
         };
       }
     }


### PR DESCRIPTION
I had to make some very small changes to our configurations to make the plugins repo prod-ready. It _looked_ like it was ready in the last push, but the prod build wasn't connecting to the pincs lessons site.

I was able to confirm that running both prod (npm run build:plugins + npm run preview:plugins) and local (npm start) interface successfully with the lessons site, depending on the site config set in the .env. Now just to see if it works on our servers...