### PR TITLE
Add riemann-sum plugin for Riemann sums lesson

### DIFF
--- a/src/Sandbox/Sandbox.tsx
+++ b/src/Sandbox/Sandbox.tsx
@@ -17,6 +17,17 @@ async function loadImplementationCode(name: string): Promise<string> {
   return res.text();
 }
 
+async function loadStarterCode(name: string): Promise<string> {
+  const url = `/plugins-code/${name}/languages/BasicJS/starter-code/main.js`;
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return "";
+    return res.text();
+  } catch {
+    return "";
+  }
+}
+
 export const Sandbox = () => {
   const { pluginName } = useParams();
   const jsRuntimeRef = useRef<JSRuntime>(null);
@@ -26,17 +37,21 @@ export const Sandbox = () => {
   const [codeText, setCodeText] = useState("");
 
   useEffect(() => {
-    const codeText = localStorage.getItem("codeText");
-    if (codeText) {
-      setCodeText(codeText);
-    }
-  }, []);
-
-  useEffect(() => {
     if (!pluginName) return;
+
     loadImplementationCode(pluginName).then((c) => {
       setImplementation(c);
     });
+
+    const storageKey = `codeText-${pluginName}`;
+    const saved = localStorage.getItem(storageKey);
+    if (saved) {
+      setCodeText(saved);
+    } else {
+      loadStarterCode(pluginName).then((code) => {
+        if (code) setCodeText(code);
+      });
+    }
   }, [pluginName]);
 
   return (
@@ -49,7 +64,7 @@ export const Sandbox = () => {
           extensions={[javascript()]}
           onChange={(value) => {
             setCodeText(value);
-            localStorage.setItem("codeText", value);
+            localStorage.setItem(`codeText-${pluginName}`, value);
           }}
         />
       </div>

--- a/src/plugins/riemann-sum/Component.tsx
+++ b/src/plugins/riemann-sum/Component.tsx
@@ -1,0 +1,283 @@
+import { observer } from "mobx-react-lite";
+import State from "./state";
+
+const EXACT_AREA = 64 / 3;
+const X_MIN = 0;
+const X_MAX = 4;
+const Y_MAX = 16;
+
+const Component = observer(({ state }: { state: State | undefined }) => {
+    const rects = state?.rects ?? [];
+    const curveVisible = state?.curveVisible ?? false;
+    const area = state?.area ?? 0;
+    const n = rects.length;
+
+    const vw = 520;
+    const vh = 420;
+    const pad = { top: 24, right: 24, bottom: 44, left: 52 };
+    const plotW = vw - pad.left - pad.right;
+    const plotH = vh - pad.top - pad.bottom;
+
+    const sx = (x: number) =>
+        pad.left + ((x - X_MIN) / (X_MAX - X_MIN)) * plotW;
+    const sy = (y: number) => pad.top + plotH - (y / Y_MAX) * plotH;
+
+    const curvePoints = curveVisible
+        ? Array.from({ length: 201 }, (_, i) => {
+              const x = (i / 200) * X_MAX;
+              return `${sx(x)},${sy(Math.min(x * x, Y_MAX))}`;
+          }).join(" ")
+        : "";
+
+    return (
+        <div
+            style={{
+                display: "flex",
+                flexDirection: "column",
+                height: "100%",
+                width: "100%",
+                background: "#101828",
+                color: "#e0e0e0",
+                fontFamily: "'Segoe UI', system-ui, sans-serif",
+                overflow: "hidden",
+            }}
+        >
+            <div
+                style={{
+                    padding: "14px 20px 6px",
+                    fontSize: "16px",
+                    fontWeight: 700,
+                    color: "#fff",
+                    letterSpacing: "0.3px",
+                }}
+            >
+                Riemann Sum: f(x) = x&sup2; on [0, 4]
+            </div>
+
+            <div
+                style={{
+                    flex: 1,
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    padding: "4px 12px",
+                    minHeight: 0,
+                }}
+            >
+                <svg
+                    viewBox={`0 0 ${vw} ${vh}`}
+                    style={{ width: "100%", height: "100%" }}
+                    preserveAspectRatio="xMidYMid meet"
+                >
+                    <rect
+                        x={pad.left}
+                        y={pad.top}
+                        width={plotW}
+                        height={plotH}
+                        fill="#1a2332"
+                        rx="4"
+                    />
+
+                    {[4, 8, 12, 16].map((v) => (
+                        <line
+                            key={`gy-${v}`}
+                            x1={pad.left}
+                            y1={sy(v)}
+                            x2={pad.left + plotW}
+                            y2={sy(v)}
+                            stroke="rgba(255,255,255,0.06)"
+                        />
+                    ))}
+                    {[1, 2, 3, 4].map((v) => (
+                        <line
+                            key={`gx-${v}`}
+                            x1={sx(v)}
+                            y1={pad.top}
+                            x2={sx(v)}
+                            y2={pad.top + plotH}
+                            stroke="rgba(255,255,255,0.06)"
+                        />
+                    ))}
+
+                    {rects.map((r, i) => {
+                        const h = Math.min(r.height, Y_MAX);
+                        if (h <= 0) return null;
+                        return (
+                            <rect
+                                key={i}
+                                x={sx(r.x)}
+                                y={sy(h)}
+                                width={sx(r.x + r.width) - sx(r.x)}
+                                height={sy(0) - sy(h)}
+                                fill={r.color}
+                                fillOpacity={0.45}
+                                stroke={r.color}
+                                strokeWidth={n > 40 ? 0.3 : 1}
+                            />
+                        );
+                    })}
+
+                    {curveVisible && (
+                        <polyline
+                            points={curvePoints}
+                            fill="none"
+                            stroke="#4fc3f7"
+                            strokeWidth="2.5"
+                            strokeLinejoin="round"
+                        />
+                    )}
+
+                    <line
+                        x1={pad.left}
+                        y1={sy(0)}
+                        x2={pad.left + plotW}
+                        y2={sy(0)}
+                        stroke="#8899aa"
+                        strokeWidth="1.5"
+                    />
+                    <line
+                        x1={pad.left}
+                        y1={pad.top}
+                        x2={pad.left}
+                        y2={sy(0)}
+                        stroke="#8899aa"
+                        strokeWidth="1.5"
+                    />
+
+                    {[0, 1, 2, 3, 4].map((v) => (
+                        <g key={`xt-${v}`}>
+                            <line
+                                x1={sx(v)}
+                                y1={sy(0)}
+                                x2={sx(v)}
+                                y2={sy(0) + 6}
+                                stroke="#8899aa"
+                            />
+                            <text
+                                x={sx(v)}
+                                y={sy(0) + 22}
+                                fill="#99aabb"
+                                fontSize="13"
+                                textAnchor="middle"
+                            >
+                                {v}
+                            </text>
+                        </g>
+                    ))}
+                    {[0, 4, 8, 12, 16].map((v) => (
+                        <g key={`yt-${v}`}>
+                            <line
+                                x1={pad.left - 6}
+                                y1={sy(v)}
+                                x2={pad.left}
+                                y2={sy(v)}
+                                stroke="#8899aa"
+                            />
+                            <text
+                                x={pad.left - 12}
+                                y={sy(v) + 4}
+                                fill="#99aabb"
+                                fontSize="13"
+                                textAnchor="end"
+                            >
+                                {v}
+                            </text>
+                        </g>
+                    ))}
+
+                    <text
+                        x={pad.left + plotW / 2}
+                        y={sy(0) + 40}
+                        fill="#99aabb"
+                        fontSize="14"
+                        textAnchor="middle"
+                        fontWeight="600"
+                    >
+                        X
+                    </text>
+                    <text
+                        x={14}
+                        y={pad.top + plotH / 2}
+                        fill="#99aabb"
+                        fontSize="14"
+                        textAnchor="middle"
+                        fontWeight="600"
+                        transform={`rotate(-90, 14, ${pad.top + plotH / 2})`}
+                    >
+                        Y
+                    </text>
+                </svg>
+            </div>
+
+            <div
+                style={{
+                    display: "flex",
+                    justifyContent: "center",
+                    gap: "32px",
+                    padding: "10px 20px 16px",
+                    borderTop: "1px solid rgba(255,255,255,0.08)",
+                    flexWrap: "wrap",
+                }}
+            >
+                <StatBlock label="Rectangles (n)" value={String(n)} />
+                <StatBlock
+                    label="Approx. Area"
+                    value={area ? area.toFixed(4) : "—"}
+                    highlight
+                />
+                <StatBlock
+                    label="Exact Area"
+                    value={EXACT_AREA.toFixed(4)}
+                    muted
+                />
+                <StatBlock
+                    label="Error"
+                    value={
+                        area ? Math.abs(area - EXACT_AREA).toFixed(4) : "—"
+                    }
+                    muted
+                />
+            </div>
+        </div>
+    );
+});
+
+function StatBlock({
+    label,
+    value,
+    muted,
+    highlight,
+}: {
+    label: string;
+    value: string;
+    muted?: boolean;
+    highlight?: boolean;
+}) {
+    return (
+        <div style={{ textAlign: "center", minWidth: "90px" }}>
+            <div
+                style={{
+                    fontSize: "10px",
+                    textTransform: "uppercase",
+                    letterSpacing: "0.8px",
+                    color: muted ? "#556" : "#899",
+                    marginBottom: "3px",
+                }}
+            >
+                {label}
+            </div>
+            <div
+                style={{
+                    fontSize: "22px",
+                    fontWeight: 700,
+                    color: highlight ? "#4fc3f7" : muted ? "#667" : "#e0e0e0",
+                    fontVariantNumeric: "tabular-nums",
+                }}
+            >
+                {value}
+            </div>
+        </div>
+    );
+}
+
+export default Component;

--- a/src/plugins/riemann-sum/Plugin.tsx
+++ b/src/plugins/riemann-sum/Plugin.tsx
@@ -1,0 +1,7 @@
+import { plugin } from "../../common/plugin";
+import Component from "./Component";
+import State from "./state";
+
+export const Plugin = plugin(Component, State);
+
+export default Plugin;

--- a/src/plugins/riemann-sum/languages/BasicJS/implementation.ts
+++ b/src/plugins/riemann-sum/languages/BasicJS/implementation.ts
@@ -1,0 +1,19 @@
+import { Message } from "../../messages";
+
+const createExports = (sendMessage: (message: Message) => void) => {
+    return Promise.resolve({
+        xmin: 0,
+        xmax: 4,
+
+        drawCurve: () => sendMessage({ type: "drawCurve" }),
+
+        setColor: (color: string) => sendMessage({ type: "setColor", color }),
+
+        drawRect: (x: number, width: number, height: number) =>
+            sendMessage({ type: "drawRect", x, width, height }),
+
+        showArea: (area: number) => sendMessage({ type: "showArea", area }),
+    });
+};
+
+export default createExports;

--- a/src/plugins/riemann-sum/languages/BasicJS/starter-code/main.js
+++ b/src/plugins/riemann-sum/languages/BasicJS/starter-code/main.js
@@ -1,0 +1,34 @@
+// ========================================================
+// Change the 'n' value below to see how adding 
+// more rectangles makes our area approximation perfect. Notice
+// how the 'n' value is used both to determine the width of each rectangle
+// and the number of rectangles to draw in the for loop.
+//
+// NOTE: You only need to edit the line 'let n = 5;'. Feel free to read 
+// the other comments to see how the "For Loop" does the math!
+// ========================================================
+
+let n = 5; // <--- CHANGE THIS! Try 10, 50, or 500.
+
+drawCurve();
+setColor("orange");
+
+let dx = (xmax - xmin) / n;
+let area = 0;
+
+for (let i = 0; i < n; i++) {
+    // 1. Find the x-coordinate of the LEFT side of rectangle #i
+    let xLeft = xmin + i * dx;
+
+    // 2. Use the function f(x) = x² to find the height at this spot
+    let height = xLeft * xLeft;
+
+    // 3. DRAW: Render the rectangle on the graph
+    drawRect(xLeft, dx, height);
+    
+    // 4. ACCUMULATE: Add this rectangle's area to our "running total"
+    area += height * dx;
+}
+
+// Display the final result in the graph
+showArea(area);

--- a/src/plugins/riemann-sum/messages.ts
+++ b/src/plugins/riemann-sum/messages.ts
@@ -1,0 +1,5 @@
+export type Message =
+    | { type: "drawCurve" }
+    | { type: "setColor"; color: string }
+    | { type: "drawRect"; x: number; width: number; height: number }
+    | { type: "showArea"; area: number };

--- a/src/plugins/riemann-sum/state.ts
+++ b/src/plugins/riemann-sum/state.ts
@@ -1,0 +1,43 @@
+import { action, observable } from "mobx";
+import { Message } from "./messages";
+
+interface Rect {
+    x: number;
+    width: number;
+    height: number;
+    color: string;
+}
+
+export class State {
+    @observable accessor rects: Rect[] = [];
+    @observable accessor curveVisible: boolean = false;
+    @observable accessor currentColor: string = "orange";
+    @observable accessor area: number = 0;
+
+    public init = () => {};
+
+    @action
+    public onMessage = (m: Message) => {
+        switch (m.type) {
+            case "drawCurve":
+                this.curveVisible = true;
+                break;
+            case "setColor":
+                this.currentColor = m.color;
+                break;
+            case "drawRect":
+                this.rects.push({
+                    x: m.x,
+                    width: m.width,
+                    height: m.height,
+                    color: this.currentColor,
+                });
+                break;
+            case "showArea":
+                this.area = m.area;
+                break;
+        }
+    };
+}
+
+export default State;


### PR DESCRIPTION
Added a Pickcode that visualizes left Riemann sums for f(x) = x². Students edit n in the starter code to see how more rectangles improves the area approximation. 